### PR TITLE
fix: fetch binaries from binaries.soliditylang.org

### DIFF
--- a/docs/userguides/version-management.md
+++ b/docs/userguides/version-management.md
@@ -65,7 +65,7 @@ solcx.import_installed_solc()
 
 ## Installing Solidity
 
-py-solc-x downloads and installs precompiled binaries from [solc-bin.ethereum.org](solc-bin.ethereum.org).
+py-solc-x downloads and installs precompiled binaries from [https://binaries.soliditylang.org](https://binaries.soliditylang.org).
 Different binaries are available depending on your operating system.
 
 ## Getting Installable Versions

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -40,7 +40,7 @@ except ImportError:
     tqdm = None
 
 
-BINARY_DOWNLOAD_BASE = "https://solc-bin.ethereum.org/{}-amd64/{}"
+BINARY_DOWNLOAD_BASE = "https://binaries.soliditylang.org/{}-amd64/{}"
 SOURCE_DOWNLOAD_BASE = "https://github.com/ethereum/solidity/releases/download/v{}/{}"
 GITHUB_RELEASES = "https://api.github.com/repos/ethereum/solidity/releases?per_page=100"
 
@@ -347,7 +347,7 @@ def get_installable_solc_versions() -> List[Version]:
     data = requests.get(BINARY_DOWNLOAD_BASE.format(_get_os_name(), "list.json"))
     if data.status_code != 200:
         raise ConnectionError(
-            f"Status {data.status_code} when getting solc versions from solc-bin.ethereum.org"
+            f"Status {data.status_code} when getting solc versions from binaries.soliditylang.org"
         )
     version_list = sorted((Version(i) for i in data.json()["releases"]), reverse=True)
     version_list = [i for i in version_list if i >= MINIMAL_SOLC_VERSION]
@@ -473,7 +473,7 @@ def install_solc(
         data = requests.get(BINARY_DOWNLOAD_BASE.format(_get_os_name(), "list.json"))
         if data.status_code != 200:
             raise ConnectionError(
-                f"Status {data.status_code} when getting solc versions from solc-bin.ethereum.org"
+                f"Status {data.status_code} when getting solc versions from binaries.soliditylang.org"
             )
         try:
             filename = data.json()["releases"][str(version)]

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -473,7 +473,7 @@ def install_solc(
         data = requests.get(BINARY_DOWNLOAD_BASE.format(_get_os_name(), "list.json"))
         if data.status_code != 200:
             raise ConnectionError(
-                f"Status {data.status_code} when getting solc versions from binaries.soliditylang.org"
+                f"Status {data.status_code} when getting versions from binaries.soliditylang.org"
             )
         try:
             filename = data.json()["releases"][str(version)]


### PR DESCRIPTION
### What I did
The https://solc-bin.ethereum.org seems to no longer be maintained (or even deprecated). This was causing downloads to fail. I replaced it with https://binaries.soliditylang.org that seems to be the current URL for the binary archive (got it from the official repo: https://github.com/argotorg/solc-bin)

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
